### PR TITLE
Delete organization

### DIFF
--- a/src/components/MemberTeams.tsx
+++ b/src/components/MemberTeams.tsx
@@ -34,7 +34,6 @@ const MemberTeams: React.FC<Props> = ({ organization_id }) => {
       <Error errorMessage={error.message || "An unexpected error occured."} />
     );
   }
-
   return (
     <div className="flex flex-col gap-y-2 rounded-md p-3">
       <p className="text-secondary text-lg sm:text-xl">

--- a/src/components/ProjectTodo.tsx
+++ b/src/components/ProjectTodo.tsx
@@ -39,7 +39,7 @@ const ProjectTodo: React.FC<Props> = ({ project_id, todo }) => {
   return (
     <li
       key={todo.id}
-      className="border-secondary mx-auto flex w-fit max-w-md flex-col gap-y-2 rounded-md border-2 p-2 shadow-lg"
+      className="border-secondary mx-auto flex w-full flex-col gap-y-2 overflow-scroll rounded-md border-2 p-2 text-wrap shadow-lg lg:max-w-md"
     >
       <span
         aria-label="todo title "
@@ -71,11 +71,6 @@ const ProjectTodo: React.FC<Props> = ({ project_id, todo }) => {
           {todo.is_finished === "yes"
             ? "Mark as unfinished"
             : "Mark as finished"}
-          {/* {mutation.isPending
-          ? "Editing todo..."
-          : todo.is_finished === "yes"
-            ? "Mark todo as unfinished"
-            : "Mark todo as finished"} */}
         </button>
       </div>
 

--- a/src/components/SortedPersonalTodos.tsx
+++ b/src/components/SortedPersonalTodos.tsx
@@ -34,7 +34,7 @@ const SortedPersonalProjectTodos: React.FC<Props> = ({
   if (error) return <Error errorMessage={error.message} />;
 
   return (
-    <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+    <ul className="grid max-w-full grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
       {todos?.map((todo: Todo) => (
         <ProjectTodo key={todo.id} project_id={project_id} todo={todo} />
       ))}

--- a/src/components/Submission.tsx
+++ b/src/components/Submission.tsx
@@ -5,6 +5,8 @@ import DeleteUserTaskSubmissionModal from "./modals/DeleteUserTaskSubmissionModa
 import { RootState } from "../store";
 import { useState } from "react";
 import ReviewTeamTaskSubmissionModal from "./modals/ReviewTeamTaskSubmissionModal";
+import useGetTeamMemberRole from "../hooks/useGetTeamMemberRole";
+import Loading from "./ui/Loading";
 
 interface SubmissionType {
   submission: TeamTaskSubmission;
@@ -18,15 +20,22 @@ const Submission: React.FC<SubmissionType> = ({ submission }) => {
     handleActiveUserSubmission,
   } = useModalContext();
   const { user } = useSelector((state: RootState) => state.auth);
+  const [reviewStatus, setReviewStatus] = useState<string | null>("");
   const handleClose = () => {
     handleActiveModal(null);
     handleActiveUserSubmission(null);
   };
-  const [reviewStatus, setReviewStatus] = useState<string | null>("");
+  const {
+    data: userRole,
+    isPending,
+    // error : userRoleError,
+  } = useGetTeamMemberRole(submission.team_id);
+
+  if (isPending) return <Loading message={"loading submission"} />;
 
   return (
     <li className="border-secondary flex flex-col gap-y-2 rounded-md border p-2">
-      <em className="text-primary text-lg capitalize md:text-xl">
+      <em className="text-secondary text-lg capitalize md:text-xl">
         {submission.status}
       </em>
       <span>Submitted at : {dateToString(submission.created_at)}</span>
@@ -66,7 +75,8 @@ const Submission: React.FC<SubmissionType> = ({ submission }) => {
         </button>
       ) : null}
       {(user?.id === submission.admin_id ||
-        user?.id === submission.super_admin_id) &&
+        user?.id === submission.super_admin_id ||
+        userRole?.role === "admin") &&
       submission.status === "under review" ? (
         <div className="flex flex-row items-center justify-between">
           <button

--- a/src/components/TaskDescription.tsx
+++ b/src/components/TaskDescription.tsx
@@ -5,6 +5,8 @@ import { dateToString } from "../utils/helperFunctions";
 import SubmitTeamTaskModal from "./modals/SubmitTeamTaskModal";
 import { useModalContext } from "../contexts/ModalContext";
 import EmptyState from "./ui/EmptyState";
+import { useSelector } from "react-redux";
+import { RootState } from "../store";
 
 interface Props {
   task_id: string;
@@ -13,6 +15,7 @@ interface Props {
 
 const TaskDescription: React.FC<Props> = ({ task_id, team_id }) => {
   const { data: task, error, isPending } = useGetTeamTask(task_id, team_id);
+  const { user } = useSelector((state: RootState) => state.auth);
   const {
     activeModal,
     activeTeamTask,
@@ -52,7 +55,7 @@ const TaskDescription: React.FC<Props> = ({ task_id, team_id }) => {
           Assigned by : {task.assigned_by}
         </span>
       </div>
-      {task.status !== "finished" ? (
+      {task.status !== "finished" && user?.email === task.assigned_to ? (
         <button
           className="btn w-fit"
           onClick={() => {

--- a/src/components/TaskSubmissions.tsx
+++ b/src/components/TaskSubmissions.tsx
@@ -23,7 +23,7 @@ const TaskSubmissions: React.FC<Props> = ({ team_id, task_id }) => {
     return (
       <EmptyState
         button={false}
-        emptyStateText="You haven't submitted any tasks yet, any tasks you submit will appear here."
+        emptyStateText="No submissions for this task yet, all submissions for this task will appear here."
       />
     );
   console.log(submissions);

--- a/src/components/Tasks.tsx
+++ b/src/components/Tasks.tsx
@@ -48,11 +48,12 @@ const Tasks: React.FC<PropTypes> = ({
             team_id={team_id}
             userRole={userRole}
             task={task}
+            organization_id={tasks[0].organization_id}
           />
         ))}
       </ul>
     );
-
+  console.log(tasks);
   return (
     <ul className="flex flex-col gap-4">
       {tasks.map((task: Task) => (
@@ -61,6 +62,7 @@ const Tasks: React.FC<PropTypes> = ({
           team_id={team_id}
           userRole={userRole}
           task={task}
+          organization_id={tasks[0].organization_id}
         />
       ))}
     </ul>
@@ -73,10 +75,12 @@ const TaskComponent = ({
   task,
   team_id,
   userRole,
+  organization_id,
 }: {
   task: Task;
   team_id: string;
   userRole: { role: string };
+  organization_id: string;
 }) => {
   const {
     activeModal,
@@ -140,6 +144,7 @@ const TaskComponent = ({
           handleClose={() => handleActiveModal(null)}
           task_id={task.id}
           team_id={team_id}
+          organization_id={organization_id}
         />
       ) : null}
     </li>

--- a/src/components/TeamSubmissions.tsx
+++ b/src/components/TeamSubmissions.tsx
@@ -11,6 +11,7 @@ import EmptyState from "./ui/EmptyState";
 import Error from "./ui/Error";
 import Loading from "./ui/Loading";
 import toast from "react-hot-toast";
+import useGetTeamMemberRole from "../hooks/useGetTeamMemberRole";
 
 interface Props {
   team_id: string;
@@ -39,23 +40,30 @@ const TeamSubmissions: React.FC<Props> = ({ team_id, type }) => {
     isPending: isLoadingTeamData,
     error: teamDataError,
   } = useGetTeam(team_id);
+  const {
+    data: userRole,
+    isPending: isLoadingUserRole,
+    error: userRoleError,
+  } = useGetTeamMemberRole(team_id);
 
   useEffect(() => {
-    if (!user || !team_data) return;
+    if (!user || !team_data || !userRole) return;
     if (
-      user?.id !== team_data?.admin_id ||
-      user?.id !== team_data?.super_admin_id
+      user?.id !== team_data?.admin_id &&
+      user?.id !== team_data?.super_admin_id &&
+      userRole.role !== "admin"
     ) {
       toast.error("You're not authorized to access this page!");
       navigate({ to: "/dashboard/organizations", replace: true });
     }
     console.log(team_data);
-  }, [user, isLoadingTeamData, team_data]);
+  }, [user, isLoadingTeamData, isLoadingUserRole, team_data, userRole]);
 
   if (isPending)
     return <Loading message={`Loading team's ${type} submissions.`} />;
   if (error) return <Error errorMessage={error.message} />;
   if (teamDataError) return <Error errorMessage={"TEam doesn't exist."} />;
+  if (userRoleError) return <Error errorMessage={userRoleError.message} />;
 
   return (
     <div className="flex flex-col gap-y-4">

--- a/src/components/UserTasks.tsx
+++ b/src/components/UserTasks.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { dateToString, Task } from "../utils/helperFunctions";
 import useGetUserTasks from "../hooks/useGetUserTasks";
+import Loading from "./ui/Loading";
 import Error from "./ui/Error";
 import EmptyState from "./ui/EmptyState";
 import { useModalContext } from "../contexts/ModalContext";
@@ -13,17 +14,17 @@ interface Props {
 }
 
 const UserTasks: React.FC<Props> = ({ team_id, type }) => {
-  const { data: tasks, error } = useGetUserTasks(team_id, type);
+  const { data: tasks, isPending, error } = useGetUserTasks(team_id, type);
   const {
     activeModal,
     activeTeamTask,
     handleActiveModal,
     handleActiveTeamTask,
   } = useModalContext();
-
+  if (isPending) return <Loading message="Loading your tasks" />;
   if (error) return <Error errorMessage={error.message} />;
 
-  if (!error && tasks && !tasks.length)
+  if (!error && !isPending && tasks && !tasks.length)
     return (
       <EmptyState
         button={false}
@@ -53,9 +54,11 @@ const UserTasks: React.FC<Props> = ({ team_id, type }) => {
           <span aria-label="date created">
             Created at : {dateToString(task.created_at)}
           </span>{" "}
-          <span aria-label="task finished date">
-            Date finished : {dateToString(task.date_finished)}
-          </span>
+          {task.date_finished ? (
+            <span aria-label="task finished date">
+              Date finished : {dateToString(task.date_finished)}
+            </span>
+          ) : null}
           <div className="flex flex-row items-center justify-between">
             <Link
               to="/dashboard/organizations/teams/$team_id/tasks/$task_id"

--- a/src/components/modals/AddTeamTaskModal.tsx
+++ b/src/components/modals/AddTeamTaskModal.tsx
@@ -1,9 +1,9 @@
 import useCreateTeamTask from "../../hooks/useCreateTeamTask";
-import useGetOrganizationMembers from "../../hooks/useGetOrganizationMembers";
-import Loading from "../ui/Loading";
-import Error from "../ui/Error";
-import Modal from "../ui/Modal";
+import useGetTeamMembers from "../../hooks/useGetTeamMembers";
 import { Member, TaskTypes } from "../../utils/helperFunctions";
+import Error from "../ui/Error";
+import Loading from "../ui/Loading";
+import Modal from "../ui/Modal";
 
 interface Props {
   admin_id: string;
@@ -23,15 +23,10 @@ const AddTeamTaskModal: React.FC<Props> = ({
   handleActiveModal,
 }) => {
   const {
-    data: organizationMembers,
+    data: teamMembers,
     isPending,
     error,
-  } = useGetOrganizationMembers(
-    organization_id,
-    undefined,
-    admin_id,
-    super_admin_id,
-  );
+  } = useGetTeamMembers(team_id, organization_id);
   const createTaskMutation = useCreateTeamTask(
     team_id,
     () => handleActiveModal(null),
@@ -40,6 +35,7 @@ const AddTeamTaskModal: React.FC<Props> = ({
 
   if (isPending) return <Loading message="Loading organization members" />;
   if (error) return <Error errorMessage={error.message} />;
+  console.log(teamMembers);
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -90,7 +86,7 @@ const AddTeamTaskModal: React.FC<Props> = ({
             id="description"
           />
         </div>
-        {!organizationMembers || organizationMembers.length < 1 ? (
+        {!teamMembers || teamMembers.length < 1 ? (
           <span aria-label="organization members empty state text">
             You don't have any members in your organization!
           </span>
@@ -105,7 +101,7 @@ const AddTeamTaskModal: React.FC<Props> = ({
               defaultValue={""}
               aria-label="task assignee  email selection"
             >
-              {organizationMembers?.map((member: Member) => (
+              {teamMembers?.map((member: Member) => (
                 <option
                   aria-label={`email for ${member.member_email}`}
                   value={JSON.stringify({

--- a/src/components/modals/AddTeamTaskModal.tsx
+++ b/src/components/modals/AddTeamTaskModal.tsx
@@ -32,8 +32,10 @@ const AddTeamTaskModal: React.FC<Props> = ({
     admin_id,
     super_admin_id,
   );
-  const createTaskMutation = useCreateTeamTask(team_id, () =>
-    handleActiveModal(null),
+  const createTaskMutation = useCreateTeamTask(
+    team_id,
+    () => handleActiveModal(null),
+    organization_id,
   );
 
   if (isPending) return <Loading message="Loading organization members" />;
@@ -120,7 +122,6 @@ const AddTeamTaskModal: React.FC<Props> = ({
         )}
 
         <input type="hidden" value={team_id} name="team_id" id="team_id" />
-        {/* <input type="hidden" value={"unassigned"} name="status" id="status" /> */}
         <input type="hidden" value={admin_id} name="admin_id" id="admin_id" />
         <input
           type="hidden"

--- a/src/components/modals/DeleteTeamMemberModal.tsx
+++ b/src/components/modals/DeleteTeamMemberModal.tsx
@@ -11,6 +11,8 @@ const DeleteTeamMemberModal: React.FC<PropTypes> = ({ member, closeModal }) => {
   const deleteMemberMutation = useDeleteTeamMember(
     member.team_id,
     member.team_name,
+    member.organization_id,
+    closeModal,
   );
 
   return (

--- a/src/components/modals/DeleteTeamModal.tsx
+++ b/src/components/modals/DeleteTeamModal.tsx
@@ -1,0 +1,41 @@
+import useDeleteTeam from "../../hooks/useDeleteTeam";
+import { TeamType } from "../../utils/helperFunctions";
+import Modal from "../ui/Modal";
+
+interface Props {
+  team: TeamType;
+  handleClose: () => void;
+}
+
+const DeleteTeamModal: React.FC<Props> = ({ team, handleClose }) => {
+  const deleteTeamMutation = useDeleteTeam(
+    team.id,
+    team.organization_id,
+    team.name,
+    handleClose,
+  );
+  return (
+    <Modal
+      title={`Are you sure you want to delete this team (${team.name})? Deleting it will delete all tasks (finished, and unfinished).`}
+      handleClose={handleClose}
+    >
+      <div className="flex flex-row items-center justify-between gap-x-5">
+        <button
+          aria-label="Yes, i want to delete this team"
+          className="btn-error"
+          onClick={() => deleteTeamMutation.mutate()}
+        >
+          {deleteTeamMutation.isPending ? "Deleting team..." : "Yes"}
+        </button>
+        <button
+          aria-label="No, i don't want to delete this team"
+          className="btn"
+        >
+          No
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default DeleteTeamModal;

--- a/src/components/modals/EditTeamMemberRole.tsx
+++ b/src/components/modals/EditTeamMemberRole.tsx
@@ -32,10 +32,12 @@ const EditTeamMemberRoleModal: React.FC<PropTypes> = ({
         member.organization_id,
       );
       if (
-        memberRole[0].role.toLowerCase() !== "admin" &&
-        userRole[0].role.toLowerCase() !== "super admin"
+        memberRole[0].role !== "admin" &&
+        userRole[0].role !== "super admin"
       ) {
-        throw new Error("You're not authorized to make this action!");
+        throw new Error(
+          "You're not authorized to make this action. Only Organization super admins or Team admins and Team Creators can edit a team member's role",
+        );
       }
       await changeTeamMemberRole(role, member.member_id, member.team_id);
     },

--- a/src/components/modals/ReviewTeamTaskSubmissionModal.tsx
+++ b/src/components/modals/ReviewTeamTaskSubmissionModal.tsx
@@ -44,7 +44,7 @@ const ReviewTeamTaskSubmissionModal: React.FC<Props> = ({
         userTeamRole[0].role !== "admin"
       ) {
         throw new Error(
-          "You're not authorized to make this action. Only team admins or Organization SUPER ADMINS can review team task submissions!",
+          "You're not authorized to make this action. Only team Creators, TEam admins or Organization SUPER ADMINS can review team task submissions!",
         );
       }
       await reviewTaskSubmission(

--- a/src/components/modals/SubmitTeamTaskModal.tsx
+++ b/src/components/modals/SubmitTeamTaskModal.tsx
@@ -28,6 +28,8 @@ const SubmitTeamTaskModal: React.FC<Props> = ({ task }) => {
         task.id,
         task.super_admin_id,
         task.admin_id,
+        task.organization_id,
+        task.team_name,
         submission_note,
       ),
     onSuccess: () => {
@@ -60,6 +62,7 @@ const SubmitTeamTaskModal: React.FC<Props> = ({ task }) => {
       submission_note: string;
     };
     console.log(dataObject);
+    console.log(task);
     submitTaskMutation.mutate(dataObject.submission_note);
   };
 

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -7,7 +7,7 @@ interface ModalProps {
 const Modal: React.FC<ModalProps> = ({ children, title, handleClose }) => {
   return (
     <div className="fixed inset-0 z-20 flex items-center justify-center bg-white/10 backdrop-blur-sm">
-      <div className="text-text bg-background mx-5 flex flex-col items-center gap-y-4 rounded-md p-4 drop-shadow-2xl max-sm:w-full">
+      <div className="text-text bg-background mx-auto flex max-w-lg flex-col items-center gap-y-4 rounded-md p-4 drop-shadow-2xl max-sm:mx-5 max-sm:w-full">
         <IoCloseSharp
           aria-label="Close modal button"
           className="cursor-pointer self-end"

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -30,7 +30,8 @@ type ActiveModal =
   | "delete user submission"
   | "review user submission"
   | "edit organization member role"
-  | "edit team member role";
+  | "edit team member role"
+  | "delete team";
 
 interface ModalTypes {
   activeModal: ActiveModal | null;

--- a/src/hooks/useCreateTeam.ts
+++ b/src/hooks/useCreateTeam.ts
@@ -60,6 +60,12 @@ const useCreateTeam = (
         queryKey: ["organization-teams"],
       });
       queryClient.invalidateQueries({
+        queryKey: ["member-teams", organization_id],
+      });
+      queryClient.refetchQueries({
+        queryKey: ["member-teams", organization_id],
+      });
+      queryClient.invalidateQueries({
         queryKey: ["admin-teams"],
       });
       queryClient.refetchQueries({

--- a/src/hooks/useDeleteTeam.ts
+++ b/src/hooks/useDeleteTeam.ts
@@ -1,0 +1,78 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteMembers, getTeamMemberRole } from "../utils/team_members";
+import { useSelector } from "react-redux";
+import { RootState } from "../store";
+import toast from "react-hot-toast";
+import { getMemberRole } from "../utils/members";
+import { deleteTeam } from "../utils/teams";
+import { deleteTasks } from "../utils/team_tasks";
+import { deleteSubmissions } from "../utils/team_tasks_submissions";
+import { sendNotification } from "../utils/notifications";
+import { useNavigate } from "@tanstack/react-router";
+
+const useDeleteTeam = (
+  team_id: string,
+  organization_id: string,
+  team_name: string,
+  handleClose: () => void,
+) => {
+  const queryClient = useQueryClient();
+  const { user } = useSelector((state: RootState) => state.auth);
+  const navigate = useNavigate();
+  return useMutation({
+    mutationFn: async () => {
+      const userTeamRole = await getTeamMemberRole(user?.id as string, team_id);
+      const userOrganizationRole = await getMemberRole(
+        user?.id as string,
+        organization_id,
+      );
+      if (
+        userTeamRole[0].role !== "admin" &&
+        userOrganizationRole[0].role !== "super admin"
+      ) {
+        throw new Error(
+          "You're not authorized to make this action. You have to be a Team CREATOR, or an Organization SUPER ADMIN to delete a team!",
+        );
+      }
+      await deleteTeam(team_id);
+      await deleteMembers(undefined, team_id);
+      await deleteTasks(undefined, team_id);
+      await deleteSubmissions(undefined, team_id);
+      await sendNotification(
+        user?.id as string,
+        "Team deletion",
+        `Your team : ${team_name} has been deleted`,
+        user?.email as string,
+      );
+    },
+    onSuccess: () => {
+      toast.success(`${team_name} team deleted successfully!`);
+      queryClient.invalidateQueries({
+        queryKey: ["admin-teams", user?.id as string, organization_id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["team", team_id],
+      });
+      queryClient.refetchQueries({
+        queryKey: ["admin-teams", user?.id as string, organization_id],
+      });
+      queryClient.refetchQueries({
+        queryKey: ["team", team_id],
+      });
+      handleClose();
+      navigate({
+        to: "/dashboard/organizations/my_organizations",
+        replace: true,
+      });
+    },
+    onError: (err: { message: string }) => {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "An unexpected error occured, try again";
+      toast.error(message);
+    },
+  });
+};
+
+export default useDeleteTeam;

--- a/src/hooks/useDeleteTeam.ts
+++ b/src/hooks/useDeleteTeam.ts
@@ -21,17 +21,27 @@ const useDeleteTeam = (
   const navigate = useNavigate();
   return useMutation({
     mutationFn: async () => {
-      const userTeamRole = await getTeamMemberRole(user?.id as string, team_id);
-      const userOrganizationRole = await getMemberRole(
+      const deleter_team_role = await getTeamMemberRole(
+        user?.id as string,
+        team_id,
+      );
+      const deleter_organization_role = await getMemberRole(
         user?.id as string,
         organization_id,
       );
-      if (
-        userTeamRole[0].role !== "admin" &&
-        userOrganizationRole[0].role !== "super admin"
-      ) {
+
+      if (deleter_team_role[0]) {
+        if (
+          deleter_team_role[0].role !== "admin" &&
+          deleter_organization_role[0].role !== "super admin"
+        ) {
+          throw new Error(
+            "You're not authorized to make this action! only team Creators, team Admins, and Organization Super Admins can delete teams.",
+          );
+        }
+      } else if (deleter_organization_role[0].role !== "super admin") {
         throw new Error(
-          "You're not authorized to make this action. You have to be a Team CREATOR, or an Organization SUPER ADMIN to delete a team!",
+          "You're not authorized to make this action! only team Creators, team Admins, and Organization Super Admins can delete teams.",
         );
       }
       await deleteTeam(team_id);

--- a/src/hooks/useDeleteUserOrganization.ts
+++ b/src/hooks/useDeleteUserOrganization.ts
@@ -41,7 +41,10 @@ const useDeleteUserOrganization = ({
       });
       toast.success("Organization deleted successfully!");
       handleCloseModal();
-      navigate({ to: "/dashboard/organizations/my_organizations" });
+      navigate({
+        to: "/dashboard/organizations/my_organizations",
+        replace: true,
+      });
     },
     onError: (err: { message: string }) => {
       toast.error(err.message || "An unexpected error occured, try again.");
@@ -63,10 +66,10 @@ const useDeleteUserOrganization = ({
         // user?.id as string,
         organization_id,
       );
-      await deleteMembers(organization_id);
-      await deleteSubmissions(organization_id);
-      await deleteTasks(organization_id);
       await deleteOrganizationTeams(organization_id);
+      await deleteMembers(organization_id);
+      await deleteTasks(organization_id);
+      await deleteSubmissions(organization_id);
       await sendNotification(
         user?.id as string,
         "Deleted organization",

--- a/src/hooks/useGetTeamMemberRole.ts
+++ b/src/hooks/useGetTeamMemberRole.ts
@@ -7,7 +7,7 @@ const useGetTeamMemberRole = (team_id: string) => {
   const { user } = useSelector((state: RootState) => state.auth);
   return useQuery({
     queryKey: ["team-member-role", team_id],
-    queryFn: () => getTeamMemberRole(user?.id as string, team_id),
+    queryFn: async () => await getTeamMemberRole(user?.id as string, team_id),
     staleTime: Infinity,
     refetchOnMount: false,
     refetchOnWindowFocus: false,

--- a/src/routes/dashboard/organizations/my_organizations/$organization_id/index.tsx
+++ b/src/routes/dashboard/organizations/my_organizations/$organization_id/index.tsx
@@ -13,6 +13,7 @@ import useGetAdminOrganization from "../../../../../hooks/useGetAdminOrganizatio
 import { RootState } from "../../../../../store";
 import { dateToString } from "../../../../../utils/helperFunctions";
 import UpdateOrganizationDetailsModal from "../../../../../components/modals/UpdateOrganizationDetailsModal.tsx";
+import DeleteOrganizationModal from "../../../../../components/modals/DeleteOrganizationModal.tsx";
 const OrganizationTeams = lazy(
   () => import("../../../../../components/OrganizationTeams.tsx"),
 );
@@ -41,16 +42,14 @@ function RouteComponent() {
   }
 
   if (error) {
-    return (
-      <Error errorMessage={error.message || "An unexpected error occured."} />
-    );
+    return <Error errorMessage={"Organization not found."} />;
   }
 
   if (!organization || organization.length < 1)
     return (
       <div>
         <GoBack route={"/dashboard/organizations"} />
-        Data not found.
+        Organization not found.
       </div>
     );
 
@@ -146,6 +145,19 @@ function RouteComponent() {
           super_admin_id={user?.id as string}
         />
       </Suspense>
+      <button
+        className="btn-error self-end"
+        onClick={() => handleActiveModal("delete organization")}
+      >
+        Delete Organization
+      </button>
+      {activeModal === "delete organization" ? (
+        <DeleteOrganizationModal
+          organization_id={organization_id}
+          organization_name={organization.name}
+          closeModal={() => handleActiveModal(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/routes/dashboard/organizations/other_organizations/$organization_id/index.tsx
+++ b/src/routes/dashboard/organizations/other_organizations/$organization_id/index.tsx
@@ -37,7 +37,7 @@ function RouteComponent() {
   const { user } = useSelector((state: RootState) => state.auth);
 
   useEffect(() => {
-    if (!user || isPending || isFetchingUserRole) return;
+    if (!user || isPending || isFetchingUserRole || !userRole) return;
 
     if (
       (userRole.toLowerCase() !== "member" &&
@@ -57,14 +57,16 @@ function RouteComponent() {
 
   if (error) {
     toast.error(error.message);
-    return (
-      <Error
-        errorMessage={
-          error.message || "An unexpected error occured, try again."
-        }
-      />
-    );
+    return <Error errorMessage={"Organization not found!"} />;
   }
+
+  if (!data || data.length < 1)
+    return (
+      <div>
+        <GoBack route={"/dashboard/organizations"} />
+        Organization not found.
+      </div>
+    );
 
   return (
     <div className="flex flex-col gap-y-4">

--- a/src/routes/dashboard/organizations/teams/$team_id/$member_id.tsx
+++ b/src/routes/dashboard/organizations/teams/$team_id/$member_id.tsx
@@ -11,6 +11,7 @@ import { useModalContext } from "../../../../../contexts/ModalContext";
 import DeleteTeamMemberModal from "../../../../../components/modals/DeleteTeamMemberModal";
 import EditTeamMemberRoleModal from "../../../../../components/modals/EditTeamMemberRole";
 import { getMemberFinishedTasks } from "../../../../../utils/team_tasks";
+import useGetTeamMemberRole from "../../../../../hooks/useGetTeamMemberRole";
 
 export const Route = createFileRoute(
   "/dashboard/organizations/teams/$team_id/$member_id",
@@ -34,6 +35,8 @@ function RouteComponent() {
     refetchOnWindowFocus: false,
     select: (res) => res[0],
   });
+  const { data: memberRole, isPending: loadingMemberRole } =
+    useGetTeamMemberRole(team_id);
 
   const { data: tasks, isPending: isLoadingfinishedTasks } = useQuery({
     queryKey: ["user-tasks", member?.member_email],
@@ -45,7 +48,7 @@ function RouteComponent() {
 
   console.log(tasks);
 
-  if (isPending || isLoadingfinishedTasks)
+  if (isPending || isLoadingfinishedTasks || loadingMemberRole)
     return <Loading message={"Loading team member"} />;
   if (error) return <Error errorMessage={"Member not found"} />;
 
@@ -61,7 +64,7 @@ function RouteComponent() {
         </span>
         <span>Number of finished tasks : {tasks?.length} </span>
         <span>Date joined : {dateToString(member.created_at)}</span>
-        {user?.id === member.super_admin_id ? (
+        {user?.id === member.super_admin_id || memberRole?.role === "admin" ? (
           <div className="flex flex-row items-center justify-between gap-x-2">
             <button
               onClick={() => handleActiveModal("delete team member")}

--- a/src/routes/dashboard/organizations/teams/$team_id/index.tsx
+++ b/src/routes/dashboard/organizations/teams/$team_id/index.tsx
@@ -82,7 +82,9 @@ function RouteComponent() {
           team_name={team.name}
         />
       </Suspense>
-      {user?.id === team.admin_id ? (
+      {user?.id === team.admin_id ||
+      user?.id === team.super_admin_id ||
+      userRole?.role === "admin" ? (
         <button
           className="bg-error text-text self-end rounded-md p-2 disabled:cursor-not-allowed"
           // disabled

--- a/src/routes/dashboard/organizations/teams/$team_id/index.tsx
+++ b/src/routes/dashboard/organizations/teams/$team_id/index.tsx
@@ -9,6 +9,8 @@ import useGetTeam from "../../../../../hooks/useGetTeam";
 import useGetTeamMemberRole from "../../../../../hooks/useGetTeamMemberRole.ts";
 import { RootState } from "../../../../../store/index.ts";
 import { dateToString } from "../../../../../utils/helperFunctions";
+import { useModalContext } from "../../../../../contexts/ModalContext.tsx";
+import DeleteTeamModal from "../../../../../components/modals/DeleteTeamModal.tsx";
 const TeamMembers = lazy(
   () => import("../../../../../components/TeamMembers.tsx"),
 );
@@ -27,6 +29,7 @@ function RouteComponent() {
     team?.id,
   );
   const { user } = useSelector((state: RootState) => state.auth);
+  const { activeModal, handleActiveModal } = useModalContext();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -47,6 +50,8 @@ function RouteComponent() {
   if (error) {
     return <Error errorMessage={"Team doesn't exist."} />;
   }
+
+  if (!isPending && !error && !team) return <span>Team doesn't exist</span>;
 
   return (
     <div className="flex flex-col gap-y-4 md:gap-y-6">
@@ -77,14 +82,21 @@ function RouteComponent() {
           team_name={team.name}
         />
       </Suspense>
-      {userRole?.role.toLowerCase() !== "member" ? (
+      {user?.id === team.admin_id ? (
         <button
           className="bg-error text-text self-end rounded-md p-2 disabled:cursor-not-allowed"
-          disabled
+          // disabled
           aria-label="delete team button"
+          onClick={() => handleActiveModal("delete team")}
         >
           Delete team
         </button>
+      ) : null}
+      {activeModal === "delete team" ? (
+        <DeleteTeamModal
+          team={team}
+          handleClose={() => handleActiveModal(null)}
+        />
       ) : null}
     </div>
   );

--- a/src/routes/dashboard/organizations/teams/$team_id/submissions/$submission_id.tsx
+++ b/src/routes/dashboard/organizations/teams/$team_id/submissions/$submission_id.tsx
@@ -14,7 +14,7 @@ function RouteComponent() {
       <ReturnBack />
       Hello
       "/dashboard/organizations/teams/$team_id/submissions/$submission_id"!
-      <span>TEam id : {team_id}</span>
+      <span>Team id : {team_id}</span>
       <span>submission id : {submission_id}</span>
     </div>
   );

--- a/src/routes/dashboard/organizations/teams/$team_id/submissions/index.tsx
+++ b/src/routes/dashboard/organizations/teams/$team_id/submissions/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useSearch } from "@tanstack/react-router";
-import ReturnBack from "../../../../../../components/ui/ReturnBack";
 import { lazy, Suspense } from "react";
+import GoBack from "../../../../../../components/ui/GoBack";
 
 const TeamSubmissions = lazy(
   () => import("../../../../../../components/TeamSubmissions"),
@@ -25,7 +25,7 @@ function RouteComponent() {
 
   return (
     <div className="flex flex-col gap-y-4">
-      <ReturnBack />
+      <GoBack route={`/dashboard/organizations/teams/${team_id}`} />
       <Suspense fallback={<span>Loading {type} submissions...</span>}>
         <TeamSubmissions type={type} team_id={team_id} />
       </Suspense>

--- a/src/routes/dashboard/organizations/teams/$team_id/tasks/index.tsx
+++ b/src/routes/dashboard/organizations/teams/$team_id/tasks/index.tsx
@@ -46,7 +46,7 @@ function RouteComponent() {
     <div className="flex flex-col gap-y-4">
       <div className="flex flex-row items-center justify-between">
         <GoBack route={`/dashboard/organizations/teams/${team_id}`} />
-        {userRole.role.toLowerCase() === "member" ? (
+        {userRole?.role.toLowerCase() === "member" ? (
           <Link
             to="/dashboard/organizations/teams/$team_id/tasks/assigned_tasks"
             params={{ team_id }}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -14,7 +14,9 @@ function RouteComponent() {
     <div className="flex min-h-[calc(100dvh-150px)] flex-col items-center justify-center gap-y-6 text-center">
       <p className="text-3xl">
         Welcome to tasksphere,{" "}
-        {user?.id ? profileData?.display_name || "User" : ""}
+        <span className="capitalize">
+          {user?.id ? profileData?.display_name || "User" : ""}
+        </span>
       </p>
       <div className="flex flex-col gap-y-3">
         <span>Organization solution for teams and personal projects</span>

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -85,14 +85,17 @@ interface Task {
   admin_id: string;
   assigned_by: string;
   assigned_to: string;
+  assignee_id: string;
   created_at: string;
   description: string;
   id: string;
-  status: "assigned" | "unfinished" | "finished";
+  status: "unassigned" | "unfinished" | "finished";
   super_admin_id: string;
   team_id: string;
   title: string;
   date_finished: string;
+  organization_id: string;
+  team_name: string;
 }
 
 interface TeamTaskSubmission {
@@ -107,6 +110,8 @@ interface TeamTaskSubmission {
   admin_id: string;
   additional_review_note: string;
   reviewed_at: string;
+  organization_id: string;
+  team_name: string;
 }
 
 type TaskTypes = "finished" | "unfinished" | "unassigned";

--- a/src/utils/team_members.ts
+++ b/src/utils/team_members.ts
@@ -104,7 +104,7 @@ async function getMemberTeams(organization_id: string, member_id: string) {
     .select("*")
     .eq("member_id", member_id)
     .eq("organization_id", organization_id)
-    .eq("role", "Member");
+    .neq("admin_id", member_id);
 
   if (error) {
     throw new Error(error.message);

--- a/src/utils/team_tasks.ts
+++ b/src/utils/team_tasks.ts
@@ -1,16 +1,18 @@
 import supabase from "../supabase";
-import { TaskTypes } from "./helperFunctions";
+import { TaskTypes, Task } from "./helperFunctions";
 
 async function createTeamTask(
-  assigned_by: string,
-  status: TaskTypes,
-  team_id: string,
-  admin_id: string,
-  super_admin_id: string,
-  title: string,
-  description: string,
-  assigned_to?: string,
-  assignee_id?: string,
+  assigned_by: Task["assigned_by"],
+  status: Task["status"],
+  team_id: Task["team_id"],
+  admin_id: Task["admin_id"],
+  super_admin_id: Task["super_admin_id"],
+  title: Task["title"],
+  description: Task["description"],
+  organization_id: Task["organization_id"],
+  team_name: Task["team_name"],
+  assigned_to: Task["assigned_to"],
+  assignee_id: Task["assignee_id"],
 ) {
   const { data: tasks, error } = await supabase
     .from("team_tasks")
@@ -25,6 +27,8 @@ async function createTeamTask(
         title,
         description,
         assignee_id,
+        organization_id,
+        team_name,
       },
     ])
 
@@ -110,7 +114,8 @@ async function getUserTasks(
     .from("team_tasks")
     .select("*")
     .eq("team_id", team_id)
-    .eq("assigned_to", assignee_email);
+    .eq("assigned_to", assignee_email)
+    .order("created_at", { ascending: false });
 
   if (status && status !== "all") {
     query = query.eq("status", status);
@@ -125,12 +130,17 @@ async function getUserTasks(
   return tasks;
 }
 
-async function editTeamTaskStatus(status: string, task_id: string) {
+async function editTeamTaskStatus(
+  status: string,
+  task_id: string,
+  date_finished: string,
+) {
   const { data: task, error } = await supabase
     .from("team_tasks")
     .update([
       {
         status,
+        date_finished,
       },
     ])
     .eq("id", task_id);

--- a/src/utils/team_tasks_submissions.ts
+++ b/src/utils/team_tasks_submissions.ts
@@ -7,6 +7,8 @@ const submitTask = async (
   task_id: TeamTaskSubmission["task_id"],
   super_admin_id: TeamTaskSubmission["super_admin_id"],
   admin_id: TeamTaskSubmission["admin_id"],
+  organization_id: TeamTaskSubmission["organization_id"],
+  team_name: TeamTaskSubmission["team_name"],
   additional_submission_note?: TeamTaskSubmission["additional_submission_note"],
 ) => {
   const { data: submission, error } = await supabase
@@ -20,6 +22,8 @@ const submitTask = async (
         super_admin_id,
         admin_id,
         additional_submission_note,
+        organization_id,
+        team_name,
       },
     ]);
 

--- a/src/utils/teams.ts
+++ b/src/utils/teams.ts
@@ -20,14 +20,14 @@ async function createTeam(
 }
 
 async function deleteTeam(
-  deleter_id: string,
+  // deleter_id: string,
   team_id: string,
-  team_admin_id: string,
-  super_admin_id: string,
+  // team_admin_id: string,
+  // super_admin_id: string,
 ) {
-  if (deleter_id !== team_admin_id && deleter_id !== super_admin_id) {
-    throw new Error("You're not athorized to make this action.");
-  }
+  // if (deleter_id !== team_admin_id && deleter_id !== super_admin_id) {
+  //   throw new Error("You're not athorized to make this action.");
+  // }
   // delete all team tasks and members along with this.
   const { data: teams, error } = await supabase
     .from("teams")


### PR DESCRIPTION
Added additional role based control to Organization secondary admins and team secondary admins.
Organization super admins can now delete Organizations successfully.
Team secondary admins can add, delete, edit member status.
They can also assign and review tasks, and delete teams.
Fixed Team members issue (Instead of fetching team members, was fetching organization members).